### PR TITLE
v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@workos-inc/authkit-react",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-react",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.0.x"
+        "@workos-inc/authkit-js": "0.1.0"
       },
       "devDependencies": {
-        "@types/react": "^18.3.3",
+        "@types/react": "18.3.3",
         "ts-node": "^10.9.2",
         "tsup": "^8.1.2",
-        "typescript": "^5.5.3"
+        "typescript": "5.5.3"
       },
       "peerDependencies": {
         "react": "18.3.1"
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.0.4.tgz",
-      "integrity": "sha512-/ozls9FKjFiv/V7YsT4MAETWrPVDivJwG9hIg3DPeEs8NsFTRHNgz/XJDdkvUxH+GYQ0VLGFn9ri0cd/aPn/Ww=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.1.0.tgz",
+      "integrity": "sha512-XIEfw6RwGvHfih8OlSd3iVjXkPPJwi9nSBSigdQRP0xy8Px1uErg+92RD4P2uzXivi0bGWWS/yMAvlj+y7kjhg=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "AuthKit React SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -25,10 +25,10 @@
   },
   "homepage": "https://github.com/workos/authkit-react#readme",
   "devDependencies": {
-    "@types/react": "^18.3.3",
+    "@types/react": "18.3.3",
     "ts-node": "^10.9.2",
     "tsup": "^8.1.2",
-    "typescript": "^5.5.3"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "react": "18.3.1"


### PR DESCRIPTION
Adds:

* `organizationId`, `role`, `permissions` to `useAuth()`

Changes:

* `user` (from `useAuth()`) is now updated as new refresh tokens are received
* upgrades to @workos-inc/authkit-js v0.1.0

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
