### PR TITLE
v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AuthKit React SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -34,6 +34,6 @@
     "react": "18.3.1"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.2.0"
+    "@workos-inc/authkit-js": "0.2.1"
   }
 }


### PR DESCRIPTION
fixes:
* only `setState` in AuthKitProvider when data changes (previously this was happening on every refresh)
* bump authkit-js to 0.2.1

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
