### PR TITLE
Unpin React peer dependency to support React 17+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "5.5.3"
       },
       "peerDependencies": {
-        "react": "18.3.1"
+        "react": ">=17"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "5.5.3"
   },
   "peerDependencies": {
-    "react": "18.3.1"
+    "react": ">=17"
   },
   "dependencies": {
     "@workos-inc/authkit-js": "0.4.1"


### PR DESCRIPTION
This package doesn't use any APIs that aren't supported in React 17, and with `use client` everywhere things should work in React 19 as well. Relaxing the peer dependency will get rid of unnecessary warnings/errors when attempting to install with older and newer versions of React.