### PR TITLE
v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@workos-inc/authkit-react",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-react",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.4.1"
+        "@workos-inc/authkit-js": "0.5.0"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.4.1.tgz",
-      "integrity": "sha512-wjUnhhiBB2c7cXZPYHhHSV0MjHIZBdLFElLPoBl4+1xMsgR8MCBB6T4z+P5+FJkfzeoU0yztUzXtUq8ItKWBVQ=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.5.0.tgz",
+      "integrity": "sha512-Va6wkS7qHTq9g3cYT0LrbDBgGcq459ClJReFhOkMVUkiBgvwp4XsKnhWPNJ+KuBbT+4JKhRymsRgZymrJgD7tQ=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-react",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "AuthKit React SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -34,6 +34,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.4.1"
+    "@workos-inc/authkit-js": "0.5.0"
   }
 }


### PR DESCRIPTION
Bumps authkit-js to 0.5.0 (Adds the `context` parameter to `signIn`/`signUp`)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
