### PR TITLE
Update `@workos-inc/authkit-js` to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.5"
+        "@workos-inc/authkit-js": "0.6"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.5.1.tgz",
-      "integrity": "sha512-BOYrBiiINPmbkep+YGTsaJ8PiC8qtVCzZ3uN383TR9dRB/l77hEdO02EezQS5QWgMm02x503hLKdmacwWOwsMg=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.6.0.tgz",
+      "integrity": "sha512-y4giMTC122oG3bER3kLAX0kYzVBdl1xdXPWwEbFVtSsB1+vd+H34IRdKbqt1H43mGzn0d0FtTGhhpl8UkU8fDA=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.5"
+    "@workos-inc/authkit-js": "0.6"
   }
 }

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -26,6 +26,7 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
     redirectUri,
     children,
     onRedirectCallback,
+    refreshBufferInterval,
   } = props;
   const [client, setClient] = React.useState<Client>(NOOP_CLIENT);
   const [state, setState] = React.useState(initialState);
@@ -58,6 +59,7 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
           devMode,
           onRedirectCallback,
           onRefresh,
+          refreshBufferInterval,
         }).then(async (client) => {
           const user = client.getUser();
           setClient(client);
@@ -74,7 +76,7 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
     setState(initialState);
 
     return initialize();
-  }, [clientId, apiHostname, https, port, redirectUri]);
+  }, [clientId, apiHostname, https, port, redirectUri, refreshBufferInterval]);
 
   return (
     <Context.Provider value={{ ...client, ...state }}>


### PR DESCRIPTION
Updates the `@workos-inc/authkit-js` dependency to `0.6`, which gives access to the latest options, particularly `refreshBufferInterval`.