### PR TITLE
Update `@workos-inc/authkit-js` to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.6"
+        "@workos-inc/authkit-js": "0.6.1"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.6.0.tgz",
-      "integrity": "sha512-y4giMTC122oG3bER3kLAX0kYzVBdl1xdXPWwEbFVtSsB1+vd+H34IRdKbqt1H43mGzn0d0FtTGhhpl8UkU8fDA=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.6.1.tgz",
+      "integrity": "sha512-I35IyBdWQb9LHS8ikT2bt5mZpDZrwGqefMuKVC6+rsmDnBFymFMrzSw3jH7D29BB3mFsZ3gd2kq3RjUI+5MQ2g=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.6"
+    "@workos-inc/authkit-js": "0.6.1"
   }
 }


### PR DESCRIPTION
Bumps `@workos-inc/authkit-js` to latest version of `v0.6.1`.