### PR TITLE
Use explicit and bound interface for `Client`

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -62,7 +62,13 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
           refreshBufferInterval,
         }).then(async (client) => {
           const user = client.getUser();
-          setClient(client);
+          setClient({
+            getAccessToken: client.getAccessToken.bind(client),
+            getUser: client.getUser.bind(client),
+            signIn: client.signIn.bind(client),
+            signUp: client.signUp.bind(client),
+            signOut: client.signOut.bind(client),
+          });
           setState((prev) => ({ ...prev, isLoading: false, user }));
         });
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 import { createClient } from "@workos-inc/authkit-js";
 
-export type Client = Awaited<ReturnType<typeof createClient>>;
+export type Client = Pick<
+  Awaited<ReturnType<typeof createClient>>,
+  "signIn" | "signUp" | "getUser" | "getAccessToken" | "signOut"
+>;
+
 export type CreateClientOptions = NonNullable<
   Parameters<typeof createClient>[1]
 >;


### PR DESCRIPTION
[With recent changes to `@workos-inc/authkit-js`](https://github.com/workos/authkit-js/commit/5f81fe19b8fd4b14716bef7eb1aba3cd4f84ab87), the return value of `createCilent` is now an instance of a class. This means it is no longer safe to spread that direct value onto the `value` of the provider, for two reasons, along with their fixes:

1. The methods from the class would lose access to the instance – So instead we bind them to the `client` explicitly.
2. Other properties, including `#private` ones, would also be spread. So instead, we derive an explicit interface via `Pick` and only return those values (after they are also bound).

These changes are backwards compatible with the old version of `@workos-inc/authkit-js` which returned a plain object, and forwards compatible with the class instance. 