### PR TITLE
Bump dependency on `@workos-inc/authkit-js` to `0.9.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.8.1"
+        "@workos-inc/authkit-js": "0.9.0"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -794,9 +794,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.8.1.tgz",
-      "integrity": "sha512-Icrx9I8M3bCgRwxajLnorNEStycXQONmzSH6UvbM2x0AkZ/dXG6WYTymwmW+hc1bkEQqGLaUEW+QcCyFDS4f+A=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.9.0.tgz",
+      "integrity": "sha512-zcl2W9LpmoIqDTnFnv6vHfWKJjZUTxZIdw5IfPL5DDTKrvH49qIRudmMIP4dCWYXIKcnMVA5lGU/PuHsimTjDQ=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.8.1"
+    "@workos-inc/authkit-js": "0.9.0"
   }
 }


### PR DESCRIPTION
Updates `@workos-inc/authkit-js` to `0.9.0` to make additions to the `signOut` helper available.