### PR TITLE
upgrade authkit-js to v0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.10.1"
+        "@workos-inc/authkit-js": "0.11.0"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -794,9 +794,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.10.1.tgz",
-      "integrity": "sha512-31JRllSL+m4bu0GtCyZOoipi4PkVdzYNqy/IJL2k4bfhtcRnHN3eEUo95j047HY2VykmTTL4FlZ52rFbCm6a2w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.11.0.tgz",
+      "integrity": "sha512-RL05tPt6bTsmnubWvgjonjKwx9vHiQXz7ZdEibqMfNDM9Pxult3Y3k3i5RSEX1MsfELMv0y5OsEktyaYG0RsPw==",
       "license": "MIT"
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.10.1"
+    "@workos-inc/authkit-js": "0.11.0"
   }
 }

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -110,11 +110,25 @@ function isEquivalentWorkOSSession(
   );
 }
 
+function noopSignOut(options?: { returnTo?: string; navigate?: true }): void;
+function noopSignOut(options?: {
+  returnTo?: string;
+  navigate: false;
+}): Promise<void>;
+function noopSignOut(options?: {
+  returnTo?: string;
+  navigate?: boolean;
+}): void | Promise<void> {
+  if (options?.navigate === false) {
+    return Promise.resolve();
+  }
+}
+
 const NOOP_CLIENT: Client = {
   signIn: async () => {},
   signUp: async () => {},
   getUser: () => null,
   getAccessToken: () => Promise.reject(new LoginRequiredError()),
   switchToOrganization: () => Promise.resolve(),
-  signOut: () => {},
+  signOut: noopSignOut,
 };

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -110,25 +110,11 @@ function isEquivalentWorkOSSession(
   );
 }
 
-function noopSignOut(options?: { returnTo?: string; navigate?: true }): void;
-function noopSignOut(options?: {
-  returnTo?: string;
-  navigate: false;
-}): Promise<void>;
-function noopSignOut(options?: {
-  returnTo?: string;
-  navigate?: boolean;
-}): void | Promise<void> {
-  if (options?.navigate === false) {
-    return Promise.resolve();
-  }
-}
-
 const NOOP_CLIENT: Client = {
   signIn: async () => {},
   signUp: async () => {},
   getUser: () => null,
   getAccessToken: () => Promise.reject(new LoginRequiredError()),
   switchToOrganization: () => Promise.resolve(),
-  signOut: noopSignOut,
+  signOut: async () => {},
 };


### PR DESCRIPTION
This pull request updates the version of the `@workos-inc/authkit-js` dependency in the `package.json` file to ensure compatibility with the latest features and bug fixes.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40-R40): Upgraded `@workos-inc/authkit-js` from version `0.10.1` to `0.11.0`.

This brings in new features, including

- Added forceRefresh option to getAccessToken method (workos/authkit-js#85)
- Deprecated context parameter on getAuthorizationUrl and signIn methods (workos/authkit-js#83)
- Removed 'impersonation coming soon' error message (workos/authkit-js#80)