### PR TITLE
feat: Add useAccessToken and useTokenClaims hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.11.0"
+        "@workos-inc/authkit-js": "0.12.0"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -794,9 +794,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.11.0.tgz",
-      "integrity": "sha512-RL05tPt6bTsmnubWvgjonjKwx9vHiQXz7ZdEibqMfNDM9Pxult3Y3k3i5RSEX1MsfELMv0y5OsEktyaYG0RsPw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.12.0.tgz",
+      "integrity": "sha512-InOA64y3IEbv13vzGJdAdz/HHWiEVzOCZxx0xDAQBxIOXciK5yUiFRUJLlpv1LJa+J5w4aDGOnMABSk7X9cLpA==",
       "license": "MIT"
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.11.0"
+    "@workos-inc/authkit-js": "0.12.0"
   }
 }

--- a/src/accessToken.ts
+++ b/src/accessToken.ts
@@ -1,0 +1,222 @@
+import { getClaims, type JwtPayload } from "@workos-inc/authkit-js";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useAuth } from "./hook";
+
+interface TokenState {
+  token: string | undefined;
+  loading: boolean;
+  error: Error | null;
+}
+
+type TokenAction =
+  | { type: "FETCH_START" }
+  | { type: "FETCH_SUCCESS"; token: string | undefined }
+  | { type: "FETCH_ERROR"; error: Error }
+  | { type: "RESET" };
+
+function tokenReducer(state: TokenState, action: TokenAction): TokenState {
+  switch (action.type) {
+    case "FETCH_START":
+      return { ...state, loading: true, error: null };
+    case "FETCH_SUCCESS":
+      return { ...state, loading: false, token: action.token };
+    case "FETCH_ERROR":
+      return { ...state, loading: false, error: action.error };
+    case "RESET":
+      return { ...state, token: undefined, loading: false, error: null };
+    // istanbul ignore next
+    default:
+      return state;
+  }
+}
+
+const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
+const MIN_REFRESH_DELAY_SECONDS = 15; // minimum delay before refreshing token
+const RETRY_DELAY_SECONDS = 300; // 5 minutes
+
+interface TokenData {
+  exp: number;
+  timeUntilExpiry: number;
+  isExpiring: boolean;
+}
+
+function parseToken(token: string): TokenData | null {
+  try {
+    const claims = getClaims(token);
+    const now = Date.now() / 1000;
+    const exp = claims.exp ?? 0;
+    const timeUntilExpiry = exp - now;
+    const isExpiring = timeUntilExpiry <= TOKEN_EXPIRY_BUFFER_SECONDS;
+
+    return { exp, timeUntilExpiry, isExpiring };
+  } catch {
+    return null;
+  }
+}
+
+function getRefreshDelay(timeUntilExpiry: number): number {
+  const refreshTime = Math.max(
+    timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS,
+    MIN_REFRESH_DELAY_SECONDS,
+  );
+  return refreshTime * 1000; // convert to milliseconds
+}
+
+/**
+ * A hook that manages access tokens with automatic refresh.
+ *
+ * @example
+ * ```ts
+ * const { accessToken, loading, error, refresh } = useAccessToken();
+ * ```
+ *
+ * @returns An object containing the access token, loading state, error state, and a refresh function.
+ */
+export function useAccessToken() {
+  const auth = useAuth();
+  const user = auth.user;
+  const userId = user?.id;
+  const [state, dispatch] = useReducer(tokenReducer, {
+    token: undefined,
+    loading: false,
+    error: null,
+  });
+
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const fetchingRef = useRef(false);
+
+  const clearRefreshTimeout = useCallback(() => {
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const updateToken = useCallback(async () => {
+    if (fetchingRef.current || !auth) {
+      return;
+    }
+
+    fetchingRef.current = true;
+    dispatch({ type: "FETCH_START" });
+    try {
+      let token = await auth.getAccessToken();
+      if (token) {
+        const tokenData = parseToken(token);
+        if (!tokenData || tokenData.isExpiring) {
+          // Force refresh by getting a new token
+          // The authkit-js client handles refresh internally
+          token = await auth.getAccessToken();
+        }
+      }
+
+      dispatch({ type: "FETCH_SUCCESS", token });
+
+      if (token) {
+        const tokenData = parseToken(token);
+        if (tokenData) {
+          const delay = getRefreshDelay(tokenData.timeUntilExpiry);
+          clearRefreshTimeout();
+          refreshTimeoutRef.current = setTimeout(updateToken, delay);
+        }
+      }
+
+      return token;
+    } catch (error) {
+      dispatch({
+        type: "FETCH_ERROR",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      refreshTimeoutRef.current = setTimeout(
+        updateToken,
+        RETRY_DELAY_SECONDS * 1000,
+      );
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [auth, clearRefreshTimeout]);
+
+  const refresh = useCallback(async () => {
+    if (fetchingRef.current || !auth) {
+      return;
+    }
+
+    fetchingRef.current = true;
+    dispatch({ type: "FETCH_START" });
+
+    try {
+      // The authkit-js client handles token refresh internally
+      const token = await auth.getAccessToken();
+
+      dispatch({ type: "FETCH_SUCCESS", token });
+
+      if (token) {
+        const tokenData = parseToken(token);
+        if (tokenData) {
+          const delay = getRefreshDelay(tokenData.timeUntilExpiry);
+          clearRefreshTimeout();
+          refreshTimeoutRef.current = setTimeout(updateToken, delay);
+        }
+      }
+
+      return token;
+    } catch (error) {
+      const typedError =
+        error instanceof Error ? error : new Error(String(error));
+      dispatch({ type: "FETCH_ERROR", error: typedError });
+      refreshTimeoutRef.current = setTimeout(
+        updateToken,
+        RETRY_DELAY_SECONDS * 1000,
+      );
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [auth, clearRefreshTimeout, updateToken]);
+
+  useEffect(() => {
+    if (!user) {
+      dispatch({ type: "RESET" });
+      clearRefreshTimeout();
+      return;
+    }
+    updateToken();
+
+    return clearRefreshTimeout;
+  }, [userId, updateToken, clearRefreshTimeout]);
+
+  return {
+    accessToken: state.token,
+    loading: state.loading,
+    error: state.error,
+    refresh,
+  };
+}
+
+type TokenClaims<T> = Partial<JwtPayload & T>;
+
+/**
+ * Extracts token claims from the access token.
+ *
+ * @example
+ * ```ts
+ * const { customClaim } = useTokenClaims<{ customClaim: string }>();
+ * console.log(customClaim);
+ * ```
+ *
+ * @return The token claims as a record of key-value pairs.
+ */
+export function useTokenClaims<T = Record<string, unknown>>(): TokenClaims<T> {
+  const { accessToken } = useAccessToken();
+
+  return useMemo(() => {
+    if (!accessToken) {
+      return {};
+    }
+
+    try {
+      return getClaims<T>(accessToken);
+    } catch {
+      return {};
+    }
+  }, [accessToken]);
+}

--- a/src/accessToken.ts
+++ b/src/accessToken.ts
@@ -1,4 +1,4 @@
-import { getClaims, type JwtPayload } from "@workos-inc/authkit-js";
+import { getClaims, type JWTPayload } from "@workos-inc/authkit-js";
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useAuth } from "./hook";
 
@@ -192,7 +192,7 @@ export function useAccessToken() {
   };
 }
 
-type TokenClaims<T> = Partial<JwtPayload & T>;
+type TokenClaims<T> = Partial<JWTPayload & T>;
 
 /**
  * Extracts token claims from the access token.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { useAccessToken, useTokenClaims } from "./accessToken";
 export { useAuth } from "./hook";
 export { AuthKitProvider } from "./provider";
 export { getClaims } from "@workos-inc/authkit-js";

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { User } from "@workos-inc/authkit-js";
+import type { User } from "@workos-inc/authkit-js";
 
 export interface State {
   isLoading: boolean;


### PR DESCRIPTION
>[!NOTE]
>This is dependent on workos/authkit-js#87.

This pull request introduces new functionality for managing access tokens with automatic refresh and token claims extraction, alongside minor improvements to type imports and exports. The most significant changes include the addition of the `useAccessToken` and `useTokenClaims` hooks, updates to the `src/index.ts` exports, and a refinement in type usage for the `User` interface.

### New functionality for access tokens:

* [`src/accessToken.ts`](diffhunk://#diff-f9df3eec305b60d72e6a69e601d29663ae70897b6293bd1e7aaabbd2f28ab0d0R1-R222): Added the `useAccessToken` hook to manage access tokens with automatic refresh and error handling. It includes a reducer for token state management and utility functions for token parsing and refresh logic.
* [`src/accessToken.ts`](diffhunk://#diff-f9df3eec305b60d72e6a69e601d29663ae70897b6293bd1e7aaabbd2f28ab0d0R1-R222): Added the `useTokenClaims` hook to extract claims from access tokens, enabling developers to access custom claims in a type-safe manner.

### Updates to exports:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1): Exported the newly added `useAccessToken` and `useTokenClaims` hooks to make them available for use in other parts of the application.

### Type improvements:

* [`src/state.ts`](diffhunk://#diff-f205dae8a870fe4c43305ee8ddd660e51710768dcbf9998ce57e9f7dea83f9c2L1-R1): Changed the import of the `User` type from a regular import to a `type` import for better type-only dependency management.