### PR TITLE
Add support for `feature_flags` claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The following claims may be populated if the user is part of an organization:
 - `organizationId`: The currently-selected organization.
 - `role`: The `role` of the user for the current organization.
 - `permissions`: Permissions corresponding to this role.
+- `featureFlags`: Enabled feature flags for the current organization.
 
 ## Passing Data Through Authentication Flows
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.11.0"
+        "@workos-inc/authkit-js": "0.13.0"
       },
       "devDependencies": {
         "@types/react": "18.3.3",
@@ -794,10 +794,9 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.11.0.tgz",
-      "integrity": "sha512-RL05tPt6bTsmnubWvgjonjKwx9vHiQXz7ZdEibqMfNDM9Pxult3Y3k3i5RSEX1MsfELMv0y5OsEktyaYG0RsPw==",
-      "license": "MIT"
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.13.0.tgz",
+      "integrity": "sha512-iA0Dt7D1BmY2/1s4oeA36W/aRt8/b5iyH6rP4AlgnjrcH2lUGkBgDXL76NXc0M7repkDQTMcJJ2NhCSo2rcWmg=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "react": ">=17"
   },
   "dependencies": {
-    "@workos-inc/authkit-js": "0.11.0"
+    "@workos-inc/authkit-js": "0.13.0"
   }
 }

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -36,7 +36,11 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
   const handleRefresh = React.useCallback(
     (response: OnRefreshResponse) => {
       const { user, accessToken, organizationId } = response;
-      const { role = null, permissions = [] } = getClaims(accessToken);
+      const {
+        role = null,
+        permissions = [],
+        feature_flags = [],
+      } = getClaims(accessToken);
       setState((prev) => {
         const next = {
           ...prev,
@@ -44,6 +48,7 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
           organizationId: organizationId ?? null,
           role,
           permissions,
+          featureFlags: feature_flags,
         };
         return isEquivalentWorkOSSession(prev, next) ? prev : next;
       });
@@ -106,7 +111,10 @@ function isEquivalentWorkOSSession(
     a.user?.updatedAt === b.user?.updatedAt &&
     a.organizationId === b.organizationId &&
     a.role === b.role &&
-    a.permissions.every((perm, i) => perm === b.permissions[i])
+    a.permissions.length === b.permissions.length &&
+    a.permissions.every((perm, i) => perm === b.permissions[i]) &&
+    a.featureFlags.length === b.featureFlags.length &&
+    a.featureFlags.every((flag, i) => flag === b.featureFlags[i])
   );
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,6 +6,7 @@ export interface State {
   role: string | null;
   organizationId: string | null;
   permissions: string[];
+  featureFlags: string[];
 }
 
 export const initialState: State = {
@@ -14,4 +15,5 @@ export const initialState: State = {
   role: null,
   organizationId: null,
   permissions: [],
+  featureFlags: [],
 };


### PR DESCRIPTION
Add support for the `feature_flags` claim. This claim will be exposed on the session as `featureFlags` and will contain a list of the string slugs for feature flags that are enabled for the current user session based on organization membership.
```ts
const { featureFlags } = newSession;
if (featureFlags.includes('my_flag')) {
   // ...
}
```