### PR TITLE
docs: Add destructuring to onRedirectCallback example to access state

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ function App() {
     <AuthKitProvider
       clientId="client_123"
       apiHostname="auth.example.com"
-      onRedirectCallback={(state) => {
+      onRedirectCallback={({ state }) => {
         // Access your data here
         if (state?.returnTo) {
           window.location.href = state.returnTo;


### PR DESCRIPTION
Previously the Using State section of README showed an example accessing `state` object directly in `onRedirectCallback`: 

```
<AuthKitProvider
      clientId="client_123"
      apiHostname="auth.example.com"
      onRedirectCallback={(state) => {
        // Access your data here
        if (state?.returnTo) {
          window.location.href = state.returnTo;
        }
      }}
    >
```

This correction shows state being destructured so it can be accessed:

```
<AuthKitProvider
      clientId="client_123"
      apiHostname="auth.example.com"
      onRedirectCallback={({ state }) => {
        // Access your data here
        if (state?.returnTo) {
          window.location.href = state.returnTo;
        }
      }}
    >
```