### PR TITLE
re-export errors and types from authkit-js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 export { useAuth } from "./hook";
 export { AuthKitProvider } from "./provider";
-export { getClaims, AuthKitError, LoginRequiredError } from "@workos-inc/authkit-js";
+export {
+  getClaims,
+  AuthKitError,
+  LoginRequiredError,
+} from "@workos-inc/authkit-js";
 export type {
   User,
   AuthenticationResponse,


### PR DESCRIPTION
Exporting authkit-js objects to prevent the need to install authkit-js explicitly 