### PR TITLE
fix: handle createClient rejection so isLoading resolves

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -93,6 +93,9 @@ export function AuthKitProvider(props: AuthKitProviderProps) {
             getSignUpUrl: client.getSignUpUrl.bind(client),
           });
           setState((prev) => ({ ...prev, isLoading: false, user }));
+        })
+        .catch(() => {
+          setState((prev) => ({ ...prev, isLoading: false }));
         });
       });
 


### PR DESCRIPTION
## Summary

- Adds a `.catch()` handler to the `createClient(...).then(...)` promise chain in `AuthKitProvider`
- Without this, any `createClient` rejection (network failure, DNS error, hung custom domain, misconfigured `apiHostname`) leaves `isLoading` stuck at `true` forever
- Apps can now render their unauthenticated state instead of showing a loading spinner indefinitely

Surfaced by VectorShift after an environment promotion where a custom auth domain wasn't bootstrapped — their app showed a permanent loading state because `isLoading` never resolved.

Related: workos/authkit-js#117 (post-sleep lock timeout), workos/authkit-js (fetch timeout PR)

## Test plan

- [ ] `npm run build` passes (tsup — CJS, ESM, DTS)
- [ ] Verify in a React app: when `createClient` rejects (e.g., invalid `clientId`, unreachable `apiHostname`), `isLoading` transitions to `false` and the app renders unauthenticated UI
- [ ] Verify happy path is unaffected — normal initialization still sets `isLoading: false` with a valid user