### PR TITLE
docs: validate state.returnTo before navigating

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,14 +234,28 @@ Use `state` to preserve data across the authentication redirect:
 <AuthKitProvider
   clientId="client_01ABC123DEF456"
   onRedirectCallback={({ state }) => {
-    if (state?.returnTo) {
-      window.location.href = state.returnTo;
+    if (typeof state?.returnTo !== "string") return;
+    // `state` round-trips through the redirect as plaintext in the URL and is
+    // not validated by WorkOS, so treat it as untrusted input. Resolve it
+    // against your own origin and only navigate if it stays same-origin; this
+    // rejects absolute URLs (https://evil.com), protocol-relative URLs
+    // (//evil.com), and javascript: URIs in one step.
+    const url = new URL(state.returnTo, window.location.origin);
+    if (url.origin === window.location.origin) {
+      window.location.href = url.pathname + url.search + url.hash;
     }
   }}
 >
   <App />
 </AuthKitProvider>
 ```
+
+> [!WARNING]
+> Anything you read from `state` is **untrusted user input**. It travels as
+> plaintext in the redirect URL and WorkOS cannot validate its contents. Before
+> using a `state.returnTo`-style value to navigate, validate it as shown above —
+> never pass it directly to `window.location.href`, which would execute a
+> `javascript:` URI or follow an open-redirect to an attacker's site.
 
 ### Handling Token Refresh Failures
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,11 @@ Use `state` to preserve data across the authentication redirect:
       return;
     }
     if (url.origin === window.location.origin) {
-      window.location.href = url.pathname + url.search + url.hash;
+      // Navigate to the origin-validated absolute URL. Don't rebuild from
+      // url.pathname: a value like "https://your-app//evil.com" passes the
+      // origin check but has pathname "//evil.com", which is protocol-relative
+      // and would redirect off-site.
+      window.location.href = url.href;
     }
   }}
 >

--- a/README.md
+++ b/README.md
@@ -240,7 +240,12 @@ Use `state` to preserve data across the authentication redirect:
     // against your own origin and only navigate if it stays same-origin; this
     // rejects absolute URLs (https://evil.com), protocol-relative URLs
     // (//evil.com), and javascript: URIs in one step.
-    const url = new URL(state.returnTo, window.location.origin);
+    let url;
+    try {
+      url = new URL(state.returnTo, window.location.origin);
+    } catch {
+      return;
+    }
     if (url.origin === window.location.origin) {
       window.location.href = url.pathname + url.search + url.hash;
     }


### PR DESCRIPTION
## What

Updates the "Passing Data Through Auth Flows" README example. The previous example navigated directly to a value read from `state`:

```jsx
onRedirectCallback={({ state }) => {
  if (state?.returnTo) {
    window.location.href = state.returnTo; // unvalidated
  }
}}
```

Replaced with an origin-resolve + same-origin check, plus a `[!WARNING]` callout that `state` is untrusted input.

## Why

`state` round-trips through the OAuth redirect as plaintext in the URL and is **not** validated by WorkOS. Copying the documented example verbatim and populating `returnTo` from request-derived data yields an open redirect — or XSS, since `window.location.href = 'javascript:...'` executes. The docs are de-facto the happy path here, so the example itself was teaching the vulnerable pattern.

The replacement resolves `returnTo` against `window.location.origin` and only navigates if it stays same-origin, which rejects absolute URLs, protocol-relative `//evil.com`, and `javascript:` URIs in one step — no fragile string matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)